### PR TITLE
Set is not explicitly required

### DIFF
--- a/lib/dry/initializer/builder.rb
+++ b/lib/dry/initializer/builder.rb
@@ -1,3 +1,4 @@
+require "set"
 module Dry::Initializer
   # Rebuilds the initializer every time a new argument defined
   #


### PR DESCRIPTION
When trying the examples from the README in a fresh IRB shell, it results in a `NameError: uninitialized constant Dry::Initializer::Builder::Set` error, because Set has not been explicitly required.
This PR adds the explicit requirement.