### PR TITLE
Cannot use an Hash as the last parameter when there are no options and the last param has a default

### DIFF
--- a/lib/dry/initializer/signature.rb
+++ b/lib/dry/initializer/signature.rb
@@ -25,7 +25,8 @@ module Dry::Initializer
     end
 
     def call
-      (select(&:param?).map(&:call) + %w(**__options__)).compact.join(", ")
+      options = all?(&:param?) ? %w(__options__={}) : %w(**__options__)
+      (select(&:param?).map(&:call) + options).compact.join(", ")
     end
 
     private

--- a/spec/default_values_spec.rb
+++ b/spec/default_values_spec.rb
@@ -48,4 +48,36 @@ describe "default values" do
     subject = Test::Foo.new
     expect(subject.mox).to eql :MOX
   end
+
+  describe "when the last param has a default and there are no options" do
+    before do
+      class Test::Bar
+        extend Dry::Initializer::Mixin
+
+        param  :foo
+        param  :bar, default: proc { {} }
+      end
+    end
+
+    it "instantiate arguments" do
+      subject = Test::Bar.new(1, 2)
+
+      expect(subject.foo).to eql 1
+      expect(subject.bar).to eql 2
+    end
+
+    it "applies default values" do
+      subject = Test::Bar.new(1)
+
+      expect(subject.foo).to eql 1
+      expect(subject.bar).to eql({})
+    end
+
+    it "instantiate arguments also if the last is an hash" do
+      subject = Test::Bar.new(1, { baz: 2, qux: 3 })
+
+      expect(subject.foo).to eql 1
+      expect(subject.bar).to eql({ baz: 2, qux: 3 })
+    end
+  end
 end


### PR DESCRIPTION
Hello, I've found an edge case in ``Dry::Initializer::Signature#call``

I was attempting to migrate an existing class to dry-initializer
That class used to have an optional field defaulted to `{}`

```ruby
class Test::Bar
  attr_accessor :foo, :bar

  def initialize(foo, bar = {})
    @foo = foo
    @bar = bar
  end
end
```

Reading the documentation I refactored the class this way

```ruby
class Test::Bar
  include Dry::Initializer.define -> do
    param  :foo
    param  :bar, default: proc { {} }
  end
end
```

But all my test failted due to this strange behaviour

```ruby
a = Test::Bar.new(1, { test: true })
a.foo #=> 1
a.bar #=> {}
```

This patch will provide a default value for the ``__options__`` constructor argument in case of missing option in the initializer definition.



