### PR TITLE
Fix warnings issued by method redefinition

### DIFF
--- a/lib/dry/initializer/attribute.rb
+++ b/lib/dry/initializer/attribute.rb
@@ -59,6 +59,7 @@ module Dry::Initializer
       command = %w(private protected).include?(reader.to_s) ? reader : :public
 
       <<-RUBY.gsub(/^ *\|/, "")
+        |undef_method :#{target} if method_defined?(:#{target}) || protected_method_defined?(:#{target}) || private_method_defined?(:#{target})
         |def #{target}
         |  @#{target} unless @#{target} == Dry::Initializer::UNDEFINED
         |end

--- a/lib/dry/initializer/builder.rb
+++ b/lib/dry/initializer/builder.rb
@@ -13,6 +13,9 @@ module Dry::Initializer
     def call(mixin)
       defaults = send(:defaults)
       coercers = send(:coercers)
+      mixin.send(:undef_method, :__defaults__)   if mixin.private_method_defined?(:__defaults__)
+      mixin.send(:undef_method, :__coercers__)   if mixin.private_method_defined?(:__coercers__)
+      mixin.send(:undef_method, :__initialize__) if mixin.private_method_defined?(:__initialize__)
       mixin.send(:define_method, :__defaults__) { defaults }
       mixin.send(:define_method, :__coercers__) { coercers }
       mixin.class_eval(code, __FILE__, __LINE__ + 1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,6 @@ RSpec.configure do |config|
     example.run
     Object.send :remove_const, :Test
   end
+
+  config.warnings = true
 end


### PR DESCRIPTION
I'm planning to turn on warnings by default in ROM, it's good practice IMO to keep them clean. Currently, most of the warnings are issued by method redefinitions in dry-initializer. This commit fixes them and starts to show warnings by default when running specs.