### PR TITLE
#dry_initializer_options

### DIFF
--- a/lib/dry/initializer/attribute.rb
+++ b/lib/dry/initializer/attribute.rb
@@ -55,7 +55,7 @@ module Dry::Initializer
     end
 
     def postsetter
-      "@__options__[:#{target}] = @#{target}" \
+      "@__dry_initializer_options__[:#{target}] = @#{target}" \
       " unless @#{target} == #{undefined}"
     end
 

--- a/lib/dry/initializer/builder.rb
+++ b/lib/dry/initializer/builder.rb
@@ -43,7 +43,7 @@ module Dry::Initializer
     def code
       <<-RUBY
         def __initialize__(#{initializer_signatures})
-          @__options__ = {}
+          @__dry_initializer_options__ = {}
         #{initializer_presetters}
         #{initializer_setters}
         #{initializer_postsetters}
@@ -68,7 +68,7 @@ module Dry::Initializer
 
     def initializer_signatures
       sig = @params.map(&:initializer_signature).compact.uniq
-      sig << (sig.any? && @options.any? ? "**__options__" : "__options__ = {}")
+      sig << (sig.any? && @options.any? ? "**__dry_initializer_options__" : "__dry_initializer_options__ = {}")
       sig.join(", ")
     end
 
@@ -92,7 +92,7 @@ module Dry::Initializer
     def defined_options
       if @options.any?
         keys = @options.map(&:target).join(" ")
-        "__options__.select { |key| %i(#{keys}).include? key }"
+        "__dry_initializer_options__.select { |key| %i(#{keys}).include? key }"
       else
         "{}"
       end

--- a/lib/dry/initializer/instance_dsl.rb
+++ b/lib/dry/initializer/instance_dsl.rb
@@ -1,5 +1,12 @@
 module Dry::Initializer
   module InstanceDSL
+    def dry_initializer_options
+      h = @__dry_initializer_options__.map do |accessor, _|
+        [accessor, public_send(accessor)] if respond_to?(accessor)
+      end
+      h.compact.to_h
+    end
+
     private
 
     # The method is reloaded explicitly

--- a/lib/dry/initializer/option.rb
+++ b/lib/dry/initializer/option.rb
@@ -2,7 +2,7 @@ module Dry::Initializer
   class Option < Attribute
     # part of __initializer__ definition
     def initializer_signature
-      "**__options__"
+      "**__dry_initializer_options__"
     end
 
     # parts of __initalizer__
@@ -16,7 +16,7 @@ module Dry::Initializer
 
     def fast_setter
       return safe_setter unless dispensable?
-      "@#{target} = __options__.key?(:'#{source}')" \
+      "@#{target} = __dry_initializer_options__.key?(:'#{source}')" \
                   " ? #{safe_coerced}" \
                   " : #{undefined}"
     end
@@ -38,7 +38,7 @@ module Dry::Initializer
     end
 
     def maybe_optional
-      " if __options__.key? :'#{source}'" if dispensable?
+      " if __dry_initializer_options__.key? :'#{source}'" if dispensable?
     end
 
     def safe_coerced
@@ -47,7 +47,7 @@ module Dry::Initializer
     end
 
     def safe_default
-      "__options__.fetch(:'#{source}')#{default_part}"
+      "__dry_initializer_options__.fetch(:'#{source}')#{default_part}"
     end
 
     def default_part

--- a/spec/dry_initialzer_options_spec.rb
+++ b/spec/dry_initialzer_options_spec.rb
@@ -1,0 +1,22 @@
+describe "#dry_initializer_options" do
+  subject do
+    class Test::Foo
+      extend Dry::Initializer::Mixin
+
+      param :foo
+      param :bar, ->(v) { "#{v}100" }
+
+      option :baz, default: -> { true }
+      option :caz, reader: :private
+      option :daz, ->(v) { "#{v}200" }, default: -> { "300" }
+    end
+
+    Test::Foo.new("1", "2", caz: 500)
+  end
+
+  it "returns correct options" do
+    expect(subject.dry_initializer_options).to eq(
+      foo: "1", bar: "2100", baz: true, daz: "300200"
+    )
+  end
+end

--- a/spec/options_var_spec.rb
+++ b/spec/options_var_spec.rb
@@ -1,4 +1,4 @@
-describe "@__options__" do
+describe "@__dry_initializer_options__" do
   context "when class has params" do
     before do
       class Test::Foo
@@ -12,7 +12,7 @@ describe "@__options__" do
     it "collects coerced params with default values" do
       subject = Test::Foo.new(:FOO)
 
-      expect(subject.instance_variable_get(:@__options__))
+      expect(subject.instance_variable_get(:@__dry_initializer_options__))
         .to eq({ foo: "FOO", bar: 1 })
     end
   end
@@ -31,7 +31,7 @@ describe "@__options__" do
     it "collects coerced and renamed options with default values" do
       subject = Test::Foo.new(foo: :FOO, qux: :QUX)
 
-      expect(subject.instance_variable_get(:@__options__))
+      expect(subject.instance_variable_get(:@__dry_initializer_options__))
         .to eq({ foo: :FOO, bar: 1, quxx: "QUX" })
     end
   end


### PR DESCRIPTION
1. @__options__ => @__dry_initializer_options__
2. #dry_initializer_options (see spec, must add all cases for `option` and `param` options).