### PR TITLE
Remove ::Mixin from Synopsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ require 'dry-initializer'
 require 'dry-types'
 
 class User
-  extend Dry::Initializer::Mixin
+  extend Dry::Initializer
 
   # Params of the initializer along with corresponding readers
   param  :name,  proc(&:to_s)


### PR DESCRIPTION
Why :

When we copy and paste the class definition of the synopsis section, it shows a warning message

```
[DEPRECATED] Use Dry::Initializer instead of its alias Dry::Initializer::Mixin. The later will be removed in v2.1.0
```