### PR TITLE
yard outdated docs

### DIFF
--- a/lib/dry/initializer.rb
+++ b/lib/dry/initializer.rb
@@ -27,8 +27,7 @@ module Dry
 
     # Adds or redefines a parameter of [#dry_initializer]
     # @param  [Symbol]       name
-    # @param  [#call, nil]   coercer (nil)
-    # @option opts [#call]   :type
+    # @param  [#call, nil]   type (nil)
     # @option opts [Proc]    :default
     # @option opts [Boolean] :optional
     # @option opts [Symbol]  :as

--- a/lib/dry/initializer/config.rb
+++ b/lib/dry/initializer/config.rb
@@ -51,8 +51,7 @@ module Dry::Initializer
 
     # Adds or redefines a parameter
     # @param  [Symbol]       name
-    # @param  [#call, nil]   coercer (nil)
-    # @option opts [#call]   :type
+    # @param  [#call, nil]   type (nil)
     # @option opts [Proc]    :default
     # @option opts [Boolean] :optional
     # @option opts [Symbol]  :as


### PR DESCRIPTION
It seems that some of the implementation details have changed and type is an argument not an option; https://app.coditsu.io/dry-rb/builds/validations/e40accc4-712f-4b15-8fb7-87d03a4a2560/offenses?q[offense_name_cont]=UnknownParameterName