### PR TITLE
Allow explicitly setting undefined as true

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ require 'dry-initializer'
 require 'dry-types'
 
 class User
-  extend Dry::Initializer
+  extend Dry::Initializer[undefined: true]
 
   # Params of the initializer along with corresponding readers
   param  :name,  proc(&:to_s)

--- a/lib/dry/initializer/builders/reader.rb
+++ b/lib/dry/initializer/builders/reader.rb
@@ -36,9 +36,10 @@ module Dry::Initializer::Builders
     def method_lines
       return unless @reader
       return unless @null
+
       [
         "def #{@target}",
-        "  #{@ivar} unless #{@ivar} == Dry::Initializer::UNDEFINED",
+        "  #{@ivar} unless #{@ivar} == Dry::Initializer::UNDEFINED && !#{@null == true}",
         "end"
       ]
     end

--- a/lib/dry/initializer/dsl.rb
+++ b/lib/dry/initializer/dsl.rb
@@ -9,8 +9,12 @@ module Dry::Initializer
     # @option settings [Boolean] :undefined
     #   If unassigned params and options should be treated different from nil
     # @return [Dry::Initializer]
-    def [](undefined: true, **)
-      null = (undefined == false) ? nil : UNDEFINED
+    def [](undefined: UNDEFINED, **)
+      null = case undefined
+             when UNDEFINED then UNDEFINED
+             when false     then nil
+             when true      then true
+             end
       Module.new.tap do |mod|
         mod.extend DSL
         mod.include self

--- a/spec/optional_spec.rb
+++ b/spec/optional_spec.rb
@@ -46,6 +46,23 @@ describe "optional value" do
     end
   end
 
+  context "with undefined: true" do
+    before do
+      class Test::Foo
+        extend Dry::Initializer[undefined: true]
+
+        param :foo
+        param :bar, optional: true
+      end
+    end
+
+    it "sets undefined values to UNDEFINED" do
+      subject = Test::Foo.new(1)
+
+      expect(subject.bar).to eq Dry::Initializer::UNDEFINED
+    end
+  end
+
   context "when has a default value" do
     before do
       class Test::Foo


### PR DESCRIPTION
Contrary to the documentation, it was not possible to have a reader return `Dry::Initializer::UNDEFINED`. 
For example, 

```ruby
class User
  extend Dry::Initializer

  option :vip,   optional: true
end

user.vip   # => Actually returns `nil`
```

Presumably, many people are depending on the current behavior. However, we would love to be able to distinguish between `nil` and `UNDEFINED` with having to access ivars. 

This PR backwards-compatibly adds the `undefined: true` option which will enable this behavior. 

The API looks like so:


```ruby
class User
  extend Dry::Initializer[undefined: true]

  option :vip,   optional: true
end

user.vip   # => Dry::Initializer::UNDEFINED
```

Happy to make any changes y'all see fit!

- Ian