### PR TITLE
Switch operands to test for undefined attribute

### DIFF
--- a/lib/dry/initializer/builders/attribute.rb
+++ b/lib/dry/initializer/builders/attribute.rb
@@ -60,22 +60,22 @@ module Dry::Initializer::Builders
 
     def default_line
       return unless @default
-      "#{@val} = instance_exec(&#{@item}.default) if #{@val} == #{@null}"
+      "#{@val} = instance_exec(&#{@item}.default) if #{@null} == #{@val}"
     end
 
     def coercion_line
       return unless @type
       arity = @type.is_a?(Proc) ? @type.arity : @type.method(:call).arity
       if arity.abs == 1
-        "#{@val} = #{@item}.type.call(#{@val}) unless #{@val} == #{@null}"
+        "#{@val} = #{@item}.type.call(#{@val}) unless #{@null} == #{@val}"
       else
-        "#{@val} = #{@item}.type.call(#{@val}, self) unless #{@val} == #{@null}"
+        "#{@val} = #{@item}.type.call(#{@val}, self) unless #{@null} == #{@val}"
       end
     end
 
     def assignment_line
       "#{@ivar} = #{@val}" \
-      " unless #{@val} == #{@null} && instance_variable_defined?(:#{@ivar})"
+      " unless #{@null} == #{@val} && instance_variable_defined?(:#{@ivar})"
     end
   end
 end

--- a/lib/dry/initializer/builders/reader.rb
+++ b/lib/dry/initializer/builders/reader.rb
@@ -38,7 +38,7 @@ module Dry::Initializer::Builders
       return unless @null
       [
         "def #{@target}",
-        "  #{@ivar} unless #{@ivar} == Dry::Initializer::UNDEFINED",
+        "  #{@ivar} unless Dry::Initializer::UNDEFINED == #{@ivar}",
         "end"
       ]
     end


### PR DESCRIPTION
This avoids calling `#==` on arbitrary values. In some cases (such as with `ActiveRecord::AssociationRelation`), testing for equality could have side effects that can otherwise be avoided.

Fixes #39 

I "tested" this via the single script I posted in #39 but would appreciate input on how to add this to the test suite without just asserting that `#==` isn't called on attribute value.

I wasn't sure which of these comparisons was causing the issue so I just changed everything I saw as I imagine this shouldn't cause a regression (unless people are relying on the side-effect behaviour).