### PR TITLE
Correct references to Ruby 2.2 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ See full documentation on the [Dry project official site][docs]
 
 ## Benchmarks
 
-The `dry-initializer` is pretty fast for rubies 2.2+ [comparing to other libraries][benchmarks].
+The `dry-initializer` is pretty fast for rubies 2.3+ [comparing to other libraries][benchmarks].
 
 ## Compatibility
 
-Tested under rubies [compatible to MRI 2.2+](.travis.yml).
+Tested under rubies [compatible to MRI 2.3+](.travis.yml).
 
 ## Contributing
 


### PR DESCRIPTION
The latest `dry-initializer` has a gemspec requirement on Ruby 2.3+ and the only 2.3+ is tested in Travis.