### PR TITLE
Fix nil coercion

### DIFF
--- a/lib/dry/initializer/builders/attribute.rb
+++ b/lib/dry/initializer/builders/attribute.rb
@@ -20,7 +20,8 @@ module Dry::Initializer::Builders
       @default    = definition.default
       @source     = definition.source
       @ivar       = definition.ivar
-      @null       = definition.null ? "Dry::Initializer::UNDEFINED" : "nil"
+      @default_null = "Dry::Initializer::UNDEFINED"
+      @null       = definition.null ? @default_null : "nil"
       @opts       = "__dry_initializer_options__"
       @congif     = "__dry_initializer_config__"
       @item       = "__dry_initializer_definition__"
@@ -67,9 +68,11 @@ module Dry::Initializer::Builders
       return unless @type
       arity = @type.is_a?(Proc) ? @type.arity : @type.method(:call).arity
       if arity.abs == 1
-        "#{@val} = #{@item}.type.call(#{@val}) unless #{@null} == #{@val}"
+        "#{@val} = #{@item}.type.call(#{@val})" \
+        " unless #{@default_null} == #{@val}"
       else
-        "#{@val} = #{@item}.type.call(#{@val}, self) unless #{@null} == #{@val}"
+        "#{@val} = #{@item}.type.call(#{@val}, self)" \
+        " unless #{@default_null} == #{@val}"
       end
     end
 

--- a/spec/coercion_of_nil_spec.rb
+++ b/spec/coercion_of_nil_spec.rb
@@ -15,11 +15,32 @@ describe "coercion of nil" do
   let(:foo) { Test::Foo.new(nil) }
   let(:baz) { Test::Baz.new(nil) }
 
-  it "works with extend syntax" do
-    expect(foo.bar).to eq 0
+  context "default @null" do
+    it "works with extend syntax" do
+      expect(foo.bar).to eq 0
+    end
+
+    it "works with include syntax" do
+      expect(baz.qux).to eq 0
+    end
   end
 
-  it "works with include syntax" do
-    expect(baz.qux).to eq 0
+  context "@null is nil" do
+    before(:context) do
+      @default_null = Dry::Initializer.instance_variable_get :@null
+      Dry::Initializer.instance_variable_set :@null, nil
+    end
+
+    after(:context) do
+      Dry::Initializer.instance_variable_set :@null, @default_null
+    end
+
+    it "works with extend syntax" do
+      expect(foo.bar).to eq 0
+    end
+
+    it "works with include syntax" do
+      expect(baz.qux).to eq 0
+    end
   end
 end


### PR DESCRIPTION
#42 
Skip coercion only if `@val` is `UNDEFINED`.