### PR TITLE
CI: Use latest Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 ---
 language: ruby
-sudo: false
 cache: bundler
 bundler_args: --without benchmarks tools
 script:
   - bundle exec rake spec
 rvm:
-  - 2.3.0
-  - 2.4.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.5
+  - 2.6.2
   - jruby-9000
   - rbx-3
   - ruby-head


### PR DESCRIPTION
Update the CI matrix with newer versions of Ruby.

Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration