### PR TITLE
CI: Use jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ matrix:
   allow_failures:
     - rvm: rbx-3
     - rvm: ruby-head
+    - rvm: jruby-head
     - rvm: truffleruby
   include:
     - rvm: jruby-head
-      before_install: gem install bundler --no-ri --no-rdoc
+      before_install: gem install bundler --no-document

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ script:
   - bundle exec rake spec
 rvm:
   - 2.3.8
-  - 2.4.5
+  - 2.4.6
   - 2.5.5
   - 2.6.2
-  - jruby-9000
+  - jruby-9.2.7.0
   - rbx-3
   - ruby-head
   - truffleruby
@@ -20,7 +20,6 @@ matrix:
   allow_failures:
     - rvm: rbx-3
     - rvm: ruby-head
-    - rvm: jruby-head
     - rvm: truffleruby
   include:
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.5.5
   - 2.6.2
   - jruby-9.2.7.0
+  - jruby-9000
   - rbx-3
   - ruby-head
   - truffleruby


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)