### PR TITLE
Fix downcased attributes

### DIFF
--- a/lib/dry/initializer/dispatchers/prepare_target.rb
+++ b/lib/dry/initializer/dispatchers/prepare_target.rb
@@ -18,7 +18,7 @@ module Dry::Initializer::Dispatchers::PrepareTarget
 
   def call(source:, target: nil, as: nil, **options)
     target ||= as || source
-    target = target.to_s.to_sym.downcase
+    target = target.to_s.to_sym
 
     check_ruby_name!(target)
     check_reserved_names!(target)

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -16,6 +16,18 @@ describe Dry::Initializer, "dry_initializer.attributes" do
     it "collects coerced params with default values" do
       expect(subject).to eq({ foo: "FOO", bar: 1 })
     end
+
+    context "and a param name has upper-cased letters" do
+      before do
+        class Test::Foo
+          param :quxQux, default: proc { "quxQux" }
+        end
+      end
+
+      it "maintains the param's case" do
+        expect(subject).to eq({ foo: "FOO", bar: 1, quxQux: "quxQux" })
+      end
+    end
   end
 
   context "when class has options" do
@@ -33,6 +45,18 @@ describe Dry::Initializer, "dry_initializer.attributes" do
 
     it "collects coerced and renamed options with default values" do
       expect(subject).to eq({ foo: :FOO, bar: 1, quxx: "QUX" })
+    end
+
+    context "and an option name has upper-cased letters" do
+      before do
+        class Test::Foo
+          option :quxQux, default: proc { "quxQux" }
+        end
+      end
+
+      it "maintains the option's case" do
+        expect(subject).to eq({ foo: :FOO, bar: 1, quxx: "QUX", quxQux: "quxQux" })
+      end
     end
   end
 end

--- a/spec/type_argument_spec.rb
+++ b/spec/type_argument_spec.rb
@@ -13,7 +13,7 @@ describe "type argument" do
     subject { Test::Foo.new 1, bar: "2" }
 
     it "raises TypeError" do
-      expect { subject }.to raise_error TypeError, /1/
+      expect { subject }.to raise_error Dry::Types::ConstraintError, /1/
     end
   end
 
@@ -21,7 +21,7 @@ describe "type argument" do
     subject { Test::Foo.new "1", bar: 2 }
 
     it "raises TypeError" do
-      expect { subject }.to raise_error TypeError, /2/
+      expect { subject }.to raise_error Dry::Types::ConstraintError, /2/
     end
   end
 

--- a/spec/type_constraint_spec.rb
+++ b/spec/type_constraint_spec.rb
@@ -43,7 +43,7 @@ describe "type constraint" do
       subject { Test::Foo.new 1 }
 
       it "raises ArgumentError" do
-        expect { subject }.to raise_error TypeError, /1/
+        expect { subject }.to raise_error Dry::Types::ConstraintError, /1/
       end
     end
 

--- a/spec/value_coercion_via_dry_types_spec.rb
+++ b/spec/value_coercion_via_dry_types_spec.rb
@@ -3,7 +3,7 @@ require "dry-types"
 describe "value coercion via dry-types" do
   before do
     module Test::Types
-      include Dry::Types.module
+      include Dry.Types
     end
 
     class Test::Foo


### PR DESCRIPTION
[This](https://github.com/dry-rb/dry-initializer/commit/d234bad909dffb520e2fa02578ae85b0974694dc) commit forces params and options to be entirely lower-cased. This is a problem if you, for instance, want to build an API wrapper that needs to specify attributes like:

```
startDate: "2019-05-01"
```

Also a commit to fix the build and deprecation warnings.