### PR TITLE
Fix CI build, Ruby 2.3-2.4 incompatibility, accidental ActiveSupport dependency, and rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
   TargetRubyVersion:  2.3
   Exclude:
     - lib/tasks/*.rake
+    - vendor/**/*
+    - tmp/**/*
 
 Bundler/DuplicatedGem:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,9 @@ Style/Lambda:
 Style/LambdaCall:
   Enabled: false
 
+Style/ModuleFunction:
+  Enabled: false
+
 Style/RescueModifier:
   Exclude:
     - spec/**/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 cache: bundler
 bundler_args: --without benchmarks tools
 script:
-  - bundle exec rake spec
+  - bundle exec rspec
+  - bundle exec rubocop
 rvm:
   - 2.3.8
   - 2.4.6
@@ -11,7 +12,6 @@ rvm:
   - 2.6.3
   - jruby-9.2.7.0
   - jruby-9000
-  - rbx-3
   - ruby-head
   - truffleruby
 env:
@@ -19,7 +19,6 @@ env:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
 matrix:
   allow_failures:
-    - rvm: rbx-3
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: truffleruby

--- a/lib/dry/initializer/config.rb
+++ b/lib/dry/initializer/config.rb
@@ -142,7 +142,7 @@ module Dry::Initializer
         source: name,
         type:   type,
         block:  block,
-        **opts,
+        **opts
       }
 
       options = Dispatchers.call(opts)

--- a/lib/dry/initializer/struct.rb
+++ b/lib/dry/initializer/struct.rb
@@ -8,7 +8,7 @@ class Dry::Initializer::Struct
     undef_method :param
 
     def new(options)
-      super Hash(options).transform_keys(&:to_sym)
+      super Hash(options).each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
     end
     alias call new
   end
@@ -22,8 +22,7 @@ class Dry::Initializer::Struct
       .class
       .dry_initializer
       .attributes(self)
-      .transform_values { |v| __hashify(v) }
-      .stringify_keys
+      .each_with_object({}) { |(k, v), h| h[k.to_s] = __hashify(v) }
   end
 
   private

--- a/spec/nested_type_spec.rb
+++ b/spec/nested_type_spec.rb
@@ -18,6 +18,10 @@ describe "nested type argument" do
     it "builds the type" do
       expect(subject.x.y.z).to eq "42"
     end
+
+    it "converts the nested type to hash" do
+      expect(subject.x.to_h).to eq("y" => { "z" => "42" })
+    end
   end
 
   context "with nested and wrapped definitions" do

--- a/spec/type_argument_spec.rb
+++ b/spec/type_argument_spec.rb
@@ -13,7 +13,7 @@ describe "type argument" do
     subject { Test::Foo.new 1, bar: "2" }
 
     it "raises TypeError" do
-      expect { subject }.to raise_error TypeError, /1/
+      expect { subject }.to raise_error Dry::Types::ConstraintError, /1/
     end
   end
 
@@ -21,7 +21,7 @@ describe "type argument" do
     subject { Test::Foo.new "1", bar: 2 }
 
     it "raises TypeError" do
-      expect { subject }.to raise_error TypeError, /2/
+      expect { subject }.to raise_error Dry::Types::ConstraintError, /2/
     end
   end
 

--- a/spec/type_constraint_spec.rb
+++ b/spec/type_constraint_spec.rb
@@ -43,7 +43,7 @@ describe "type constraint" do
       subject { Test::Foo.new 1 }
 
       it "raises ArgumentError" do
-        expect { subject }.to raise_error TypeError, /1/
+        expect { subject }.to raise_error Dry::Types::ConstraintError, /1/
       end
     end
 

--- a/spec/value_coercion_via_dry_types_spec.rb
+++ b/spec/value_coercion_via_dry_types_spec.rb
@@ -3,7 +3,7 @@ require "dry-types"
 describe "value coercion via dry-types" do
   before do
     module Test::Types
-      include Dry::Types.module
+      include Dry.Types
     end
 
     class Test::Foo


### PR DESCRIPTION
Folks, this is a little awkward, but TravisCI has actually been returning a false negative for 2 years. The command `bundle exec rake spec` returned status 0 without running any specs. 

Here is the expected build status:
https://travis-ci.org/maxim/dry-initializer/builds/540936051

This PR does 6 things:

1. Brings RSpec back online.
2. Removes rbx because it fails to install with 404 errors. I tried to fix it, but without success.
3. Brings back rubocop, but ignores vendor/tmp directories so that we only get warned about issues in this gem
4. Rewrites `transform_keys` and `transform_values` since they weren't in Ruby 2.3
5. Rewrites `stringify_keys` since that's an ActiveSupport method
6. Fixes rubocop styles