### PR TITLE
Update example for creating alias for param

### DIFF
--- a/docsite/source/container-version.html.md
+++ b/docsite/source/container-version.html.md
@@ -26,7 +26,10 @@ require 'dry-initializer'
 
 class BaseService
   extend Dry::Initializer
-  alias_method :dependency, :param
+  
+  class << self
+    alias_method :dependency, :param
+  end
 end
 
 class ShowUser < BaseService


### PR DESCRIPTION
Wrapping `alias_method` into the `class << self`, because `alias_method :dependency, :param` does not work for me and produces such error:

```
Failure/Error: alias_method :dependency, :param

NameError:
  undefined method `param' for class `BaseService`'
```