### PR TITLE
documentation type constraints - Nested Options

### DIFF
--- a/docsite/source/type-constraints.html.md
+++ b/docsite/source/type-constraints.html.md
@@ -123,7 +123,7 @@ user.emails.class         # => Array
 user.emails.first.class   # => User::Emails
 user.emails.first.address # => "joe@example.com"
 
-user.emails.to_h # => [{ address: "joe@example.com", description: "Job email" }]
+user.emails.map(&:to_h) # => [{ address: "joe@example.com", description: "Job email" }]
 ```
 
 Notice how we mixed array wrapper with a nested type.


### PR DESCRIPTION
Update example of mapping emails to array of hashes, as it raises:
```
in `to_h': wrong element type User::Emails at 0 (expected array) (TypeError)
```