### PR TITLE
Update skip-undefined - syntax error (.define)

### DIFF
--- a/docsite/source/skip-undefined.html.md
+++ b/docsite/source/skip-undefined.html.md
@@ -34,7 +34,7 @@ extend Dry::Initializer[undefined: false]
 ```
 
 ```ruby
-include Dry::Initializer[undefined: false] -> do
+include Dry::Initializer[undefined: false].define -> do
   # ...
 end
 ```


### PR DESCRIPTION
Missing `.define` method what results in syntax error

```
: syntax error, unexpected ->, expecting end
...nitializer[undefined: false] -> do
```

```
Class.new do
  extend Dry::Initializer
  option :email, optional: true
end.new.
  instance_variable_get(:@email) # => Dry::Initializer::UNDEFINED

Class.new do
  include Dry::Initializer[undefined: false].define -> do
    option :email, optional: true
  end
end.new.
  instance_variable_get(:@email) # => nil
```