### PR TITLE
Update type-constraints - unknown keyword

### DIFF
--- a/docsite/source/type-constraints.html.md
+++ b/docsite/source/type-constraints.html.md
@@ -150,7 +150,7 @@ class Parameter
   param :location, ->(value, param) { Location.new(value, param) }
 end
 
-offset = Parameter.new "offset", location: "query"
+offset = Parameter.new "offset", "query"
 offset.name     # => "offset"
 offset.location # => "query"
 offset.location.parameter == offset # true


### PR DESCRIPTION
`location` is defined as param but passed using keyword argument (like option) what results in:
```
in `initialize': unknown keyword: location (ArgumentError)
```

Alternative option would be to change `param` to `option`.