### PR TITLE
Fix arity check

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,4 +1,8 @@
 ---
+- version: 3.0.4
+  date: unreleased
+  fixed:
+  - 'Arity check for lambdas used for coercion (@flash-gordon)'
 - version: 3.0.3
   date: '2020-01-08'
   fixed:

--- a/lib/dry/initializer/builders/attribute.rb
+++ b/lib/dry/initializer/builders/attribute.rb
@@ -71,7 +71,7 @@ module Dry::Initializer::Builders
 
       arity = @type.is_a?(Proc) ? @type.arity : @type.method(:call).arity
 
-      if arity.abs == 1
+      if arity.equal?(1) || arity.negative?
         "#{@val} = #{@item}.type.call(#{@val}) unless #{@null} == #{@val}"
       else
         "#{@val} = #{@item}.type.call(#{@val}, self) unless #{@null} == #{@val}"


### PR DESCRIPTION
Make specs work on Ruby 3. Symbol#to_proc now returns lambdas with arity -2. It's more correct but some specs in dry-initializer are failing because of this change. I fixed the arity check :wrench: