### PR TITLE
Fix typo: Remove extra "it"

### DIFF
--- a/docsite/source/optionals-and-defaults.html.md
+++ b/docsite/source/optionals-and-defaults.html.md
@@ -41,7 +41,7 @@ class User
 end
 ```
 
-You should assign `nil` value explicitly. Otherwise an instance variable it will be left undefined. In both cases attribute reader method will return `nil`.
+You should assign `nil` value explicitly. Otherwise an instance variable will be left undefined. In both cases attribute reader method will return `nil`.
 
 ```ruby
 require 'dry-initializer'


### PR DESCRIPTION
Remove extra "it" when talking about assigning `nil` explicitly.

"Otherwise an instance variable ~it~ will be left undefined."