### PR TITLE
Add field name to coercion errors

### DIFF
--- a/lib/dry/initializer.rb
+++ b/lib/dry/initializer.rb
@@ -13,6 +13,7 @@ module Dry
     require_relative "initializer/config"
     require_relative "initializer/mixin"
     require_relative "initializer/dispatchers"
+    require_relative "initializer/errors"
 
     # Adds methods [.[]] and [.define]
     extend DSL

--- a/lib/dry/initializer/builders/attribute.rb
+++ b/lib/dry/initializer/builders/attribute.rb
@@ -72,9 +72,21 @@ module Dry::Initializer::Builders
       arity = @type.is_a?(Proc) ? @type.arity : @type.method(:call).arity
 
       if arity.equal?(1) || arity.negative?
-        "#{@val} = #{@item}.type.call(#{@val}) unless #{@null} == #{@val}"
+        <<-METH
+          begin
+            #{@val} = #{@item}.type.call(#{@val}) unless #{@null} == #{@val}
+          rescue Dry::Types::ConstraintError => e
+            raise Dry::Initializer::CoercionError.new(e, '#{@source}')
+          end
+        METH
       else
-        "#{@val} = #{@item}.type.call(#{@val}, self) unless #{@null} == #{@val}"
+        <<-METH
+          begin
+            #{@val} = #{@item}.type.call(#{@val}, self) unless #{@null} == #{@val}
+          rescue Dry::Types::ConstraintError => e
+            raise Dry::Initializer::CoercionError.new(e, '#{@source}')
+          end
+        METH
       end
     end
 

--- a/lib/dry/initializer/builders/attribute.rb
+++ b/lib/dry/initializer/builders/attribute.rb
@@ -71,7 +71,7 @@ module Dry::Initializer::Builders
 
       arity = @type.is_a?(Proc) ? @type.arity : @type.method(:call).arity
       type_call_params = \
-        (arity.equal?(1) || arity.negative?) ? @val : "#{@val}, self"
+        arity.equal?(1) || arity.negative? ? @val : "#{@val}, self"
 
       <<-COERCE
         begin
@@ -82,30 +82,6 @@ module Dry::Initializer::Builders
           raise Dry::Initializer::CoercionError.new(e, '#{@source}')
         end
       COERCE
-    end
-
-    def coercion_lineSAVE
-      return unless @type
-
-      arity = @type.is_a?(Proc) ? @type.arity : @type.method(:call).arity
-
-      if arity.equal?(1) || arity.negative?
-        <<-METH
-          begin
-            #{@val} = #{@item}.type.call(#{@val}) unless #{@null} == #{@val}
-          rescue Dry::Types::ConstraintError => e
-            raise Dry::Initializer::CoercionError.new(e, '#{@source}')
-          end
-        METH
-      else
-        <<-METH
-          begin
-            #{@val} = #{@item}.type.call(#{@val}, self) unless #{@null} == #{@val}
-          rescue Dry::Types::ConstraintError => e
-            raise Dry::Initializer::CoercionError.new(e, '#{@source}')
-          end
-        METH
-      end
     end
 
     def assignment_line

--- a/lib/dry/initializer/errors.rb
+++ b/lib/dry/initializer/errors.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Dry
+  module Initializer
+    class CoercionError < ::StandardError
+      def initialize(constraint_error, field)
+        @constraint_error = constraint_error
+        @field = field
+        super(message)
+      end
+
+      # Ensure that the field name is in the error message
+      def message
+        if @constraint_error.message =~ /#{@field}/
+          @constraint_error.message
+        else
+          "#{@constraint_error.message} for field :#{@field}"
+        end
+      end
+    end
+  end
+end

--- a/spec/type_argument_spec.rb
+++ b/spec/type_argument_spec.rb
@@ -13,7 +13,7 @@ describe "type argument" do
     subject { Test::Foo.new 1, bar: "2" }
 
     it "raises TypeError" do
-      expect { subject }.to raise_error Dry::Types::ConstraintError, /1/
+      expect { subject }.to raise_error Dry::Initializer::CoercionError, /1.* for field :foo/
     end
   end
 
@@ -21,7 +21,7 @@ describe "type argument" do
     subject { Test::Foo.new "1", bar: 2 }
 
     it "raises TypeError" do
-      expect { subject }.to raise_error Dry::Types::ConstraintError, /2/
+      expect { subject }.to raise_error Dry::Initializer::CoercionError, /2.*for field :bar/
     end
   end
 

--- a/spec/type_constraint_spec.rb
+++ b/spec/type_constraint_spec.rb
@@ -48,7 +48,7 @@ describe "type constraint" do
         subject { Test::Foo.new 1 }
 
         it "raises ArgumentError" do
-          expect { subject }.to raise_error Dry::Types::ConstraintError, /1/
+          expect { subject }.to raise_error Dry::Initializer::CoercionError, /1.*for field :foo/
         end
       end
 
@@ -85,7 +85,7 @@ describe "type constraint" do
         subject { Test::Foo.new "foo" }
 
         it "raises constraint error" do
-          expect { subject }.to raise_error(Dry::Types::ConstraintError, /foo/)
+          expect { subject }.to raise_error(Dry::Initializer::CoercionError, /foo/)
         end
       end
 


### PR DESCRIPTION
Improve debuggablity of attribute coercion errors by adding the
field name to the error message if it is not already present.

Eg. this:

  `nil violates constraints (type?(Hash, nil) failed) for field :payment_plan`

instead of this:

  `nil violates constraints (type?(Hash, nil) failed)`