### PR TITLE
Remove use of ruby2_keywords

### DIFF
--- a/lib/dry/initializer/mixin/root.rb
+++ b/lib/dry/initializer/mixin/root.rb
@@ -3,9 +3,13 @@ module Dry::Initializer::Mixin
   module Root
     private
 
-    def initialize(*args)
-      __dry_initializer_initialize__(*args)
+    def initialize(*args, **kwargs)
+      puts "root initialize: #{args}, #{kwargs}"
+      if kwargs.empty?
+        __dry_initializer_initialize__(*args)
+      else
+        __dry_initializer_initialize__(*args, **kwargs)
+      end
     end
-    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
   end
 end

--- a/lib/dry/initializer/mixin/root.rb
+++ b/lib/dry/initializer/mixin/root.rb
@@ -4,7 +4,6 @@ module Dry::Initializer::Mixin
     private
 
     def initialize(*args, **kwargs)
-      puts "root initialize: #{args}, #{kwargs}"
       if kwargs.empty?
         __dry_initializer_initialize__(*args)
       else

--- a/lib/dry/initializer/mixin/root.rb
+++ b/lib/dry/initializer/mixin/root.rb
@@ -1,13 +1,19 @@
-module Dry::Initializer::Mixin
-  # @private
-  module Root
-    private
+# frozen_string_literal: true
 
-    def initialize(*args, **kwargs)
-      if kwargs.empty?
-        __dry_initializer_initialize__(*args)
-      else
-        __dry_initializer_initialize__(*args, **kwargs)
+module Dry
+  module Initializer
+    module Mixin
+      # @private
+      module Root
+        private
+
+        def initialize(*args, **kwargs)
+          if kwargs.empty?
+            __dry_initializer_initialize__(*args)
+          else
+            __dry_initializer_initialize__(*args, **kwargs)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Remove the use of ruby2_keywords to create an `initialize` method that is better behaved with explicit keyword arguments