### PR TITLE
Add attribute readers for unknown attributes

### DIFF
--- a/docsite/source/tolerance-to-unknown-arguments.html.md
+++ b/docsite/source/tolerance-to-unknown-arguments.html.md
@@ -20,3 +20,47 @@ user.respond_to? :role # => false
 User.dry_initializer.attributes(user)
 # => {}
 ```
+
+Unknown arguments are stored in a pair of properties
+
+```ruby
+user.__dry_initializer_unknown_params__  # => ['Joe']
+user.__dry_initializer_unknown_options__ # => {role: 'admin'}
+```
+
+The names of the rest params and the rest options are configurable. 
+
+```ruby
+require 'dry-initializer'
+
+class User
+  extend Dry::Initializer
+
+  rest_params :args
+  rest_options :kwargs
+end
+
+user = User.new 'Joe', role: 'admin'
+user.args   # => ['Joe']
+user.kwargs # => {role: 'admin'}
+user.respond_to? :__dry_initializer_unknown_params__  # => false
+user.respond_to? :__dry_initializer_unknown_options__ # => false
+```
+
+Setting rest params or rest options to false results in strict argument checking.
+Unknown arguments will result in ArgumentErrors.
+
+```ruby
+require 'dry-initializer'
+
+class User
+  extend Dry::Initializer
+
+  rest_params false
+  rest_options false
+end
+
+user = User.new 'Joe'         # => raises ArgumentError
+user = User.new role: 'admin' # => raises ArgumentError
+
+```

--- a/lib/dry/initializer.rb
+++ b/lib/dry/initializer.rb
@@ -47,6 +47,20 @@ module Dry
       self
     end
 
+    # Sets rest params name or turns off rest params of [#dry_initializer]
+    # @param  [Symbol, nil] name
+    def rest_params(name)
+      dry_initializer.rest_params = name
+      self
+    end
+
+    # Sets rest options name or turns off rest options of [#dry_initializer]
+    # @param  [Symbol, nil] name
+    def rest_options(name)
+      dry_initializer.rest_options = name
+      self
+    end
+
     private
 
     def inherited(klass)

--- a/lib/dry/initializer/builders/attribute.rb
+++ b/lib/dry/initializer/builders/attribute.rb
@@ -21,10 +21,9 @@ module Dry::Initializer::Builders
       @source     = definition.source
       @ivar       = definition.ivar
       @null       = definition.null ? 'Dry::Initializer::UNDEFINED' : 'nil'
-      @opts       = '__dry_initializer_options__'
       @congif     = '__dry_initializer_config__'
       @item       = '__dry_initializer_definition__'
-      @val        = @option ? '__dry_initializer_value__' : @source
+      @val        = @source
     end
     # rubocop: enable Metrics/MethodLength
 
@@ -32,26 +31,10 @@ module Dry::Initializer::Builders
       [
         '',
         definition_line,
-        reader_line,
         default_line,
         coercion_line,
         assignment_line
       ]
-    end
-
-    def reader_line
-      return unless @option
-
-      @optional ? optional_reader : required_reader
-    end
-
-    def optional_reader
-      "#{@val} = #{@opts}.fetch(:'#{@source}', #{@null})"
-    end
-
-    def required_reader
-      "#{@val} = #{@opts}.fetch(:'#{@source}')" \
-      " { raise KeyError, \"\#{self.class}: #{@definition} is required\" }"
     end
 
     def definition_line

--- a/lib/dry/initializer/builders/initializer.rb
+++ b/lib/dry/initializer/builders/initializer.rb
@@ -55,10 +55,10 @@ module Dry::Initializer::Builders
       lines = []
       lines << "@#{@config.rest_params} = #{@config.rest_params}" if @config.rest_params
 
-      if @config.rest_params && @definitions.any?(&:option) 
+      if @config.rest_params && @definitions.any?(&:option)
         lines << "@#{@config.rest_options} = #{@config.rest_options}"
       end
-      lines.map { |line| '  ' << line }
+      lines.map { |line| "  " << line }
     end
 
     def end_line

--- a/lib/dry/initializer/builders/initializer.rb
+++ b/lib/dry/initializer/builders/initializer.rb
@@ -25,7 +25,7 @@ module Dry::Initializer::Builders
         define_line,
         params_lines,
         options_lines,
-        unknown_lines,
+        rest_lines,
         end_line
       ]
     end
@@ -51,7 +51,7 @@ module Dry::Initializer::Builders
         .map { |line| '  ' << line }
     end
 
-    def unknown_lines
+    def rest_lines
       lines = []
       lines << "@#{@config.rest_params} = #{@config.rest_params}" if @config.rest_params
 

--- a/lib/dry/initializer/builders/initializer.rb
+++ b/lib/dry/initializer/builders/initializer.rb
@@ -25,6 +25,7 @@ module Dry::Initializer::Builders
         define_line,
         params_lines,
         options_lines,
+        unknown_lines,
         end_line
       ]
     end
@@ -48,6 +49,16 @@ module Dry::Initializer::Builders
       @definitions.select(&:option)
         .flat_map { |item| Attribute[item] }
         .map { |line| '  ' << line }
+    end
+
+    def unknown_lines
+      lines = []
+      lines << "@#{@config.rest_params} = #{@config.rest_params}" if @config.rest_params
+
+      if @config.rest_params && @definitions.any?(&:option) 
+        lines << "@#{@config.rest_options} = #{@config.rest_options}"
+      end
+      lines.map { |line| '  ' << line }
     end
 
     def end_line

--- a/lib/dry/initializer/builders/signature.rb
+++ b/lib/dry/initializer/builders/signature.rb
@@ -6,7 +6,14 @@ module Dry::Initializer::Builders
     end
 
     def call
-      [*required_params, *optional_params, '*', options].compact.join(', ')
+      [
+        *required_params,
+        *optional_params, 
+        rest_params,
+        *required_options,
+        *optional_options,
+        rest_options
+      ].compact.join(', ')
     end
 
     private
@@ -25,8 +32,20 @@ module Dry::Initializer::Builders
       @config.params.select(&:optional).map { |rec| "#{rec.source} = #{@null}" }
     end
 
-    def options
-      '**__dry_initializer_options__' if @options
+    def rest_params
+      "*#{@config.rest_params}" if @config.rest_params
+    end
+
+    def required_options
+      @config.options.reject(&:optional).map { |rec| "#{rec.source}:" }
+    end
+
+    def optional_options
+      @config.options.select(&:optional).map { |rec| "#{rec.source}: #{@null}" }
+    end
+
+    def rest_options
+      "**#{@config.rest_options}" if @options && @config.rest_options
     end
   end
 end

--- a/lib/dry/initializer/builders/signature.rb
+++ b/lib/dry/initializer/builders/signature.rb
@@ -8,12 +8,12 @@ module Dry::Initializer::Builders
     def call
       [
         *required_params,
-        *optional_params, 
+        *optional_params,
         rest_params,
         *required_options,
         *optional_options,
         rest_options
-      ].compact.join(', ')
+      ].compact.join(", ")
     end
 
     private

--- a/lib/dry/initializer/dispatchers/prepare_target.rb
+++ b/lib/dry/initializer/dispatchers/prepare_target.rb
@@ -9,7 +9,8 @@ module Dry::Initializer::Dispatchers::PrepareTarget
 
   # List of variable names reserved by the gem
   RESERVED = %i[
-    __dry_initializer_options__
+    __dry_initializer_unkown_params__
+    __dry_initializer_unkown_options__
     __dry_initializer_config__
     __dry_initializer_value__
     __dry_initializer_definition__

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Dry::Initializer, "dry_initializer.attributes" do
   subject { instance.class.dry_initializer.attributes(instance) }
 
@@ -14,7 +16,15 @@ describe Dry::Initializer, "dry_initializer.attributes" do
     let(:instance) { Test::Foo.new(:FOO) }
 
     it "collects coerced params with default values" do
-      expect(subject).to eq({ foo: "FOO", bar: 1 })
+      expect(subject).to eq({foo: "FOO", bar: 1})
+    end
+
+    context "with unknown params" do
+      let(:instance) { Test::Foo.new(:FOO, :BAR, :BAZ, :FUTZ) }
+
+      it "ignores extra params" do
+        expect(subject).to eq({foo: "FOO", bar: :BAR, baz: :BAZ})
+      end
     end
   end
 
@@ -32,7 +42,15 @@ describe Dry::Initializer, "dry_initializer.attributes" do
     let(:instance) { Test::Foo.new(foo: :FOO, qux: :QUX) }
 
     it "collects coerced and renamed options with default values" do
-      expect(subject).to eq({ foo: :FOO, bar: 1, quxx: "QUX" })
+      expect(subject).to eq({foo: :FOO, bar: 1, quxx: "QUX"})
+    end
+
+    context "with extra unknown options" do
+      let(:instance) { Test::Foo.new(foo: :FOO, qux: :QUX, futz: :FUTZ) }
+
+      it "ignores extra options" do
+        expect(subject).to eq({foo: :FOO, bar: 1, quxx: "QUX"})
+      end
     end
   end
 end

--- a/spec/required_spec.rb
+++ b/spec/required_spec.rb
@@ -11,7 +11,7 @@ describe "required param" do
   end
 
   it "raise ArgumentError" do
-    expect { Test::Foo.new() }.to raise_exception(ArgumentError)
+    expect { Test::Foo.new }.to raise_exception(ArgumentError)
   end
 end
 
@@ -26,6 +26,6 @@ describe "required option" do
   end
 
   it "raise ArgumentError" do
-    expect { Test::Foo.new() }.to raise_exception(ArgumentError)
+    expect { Test::Foo.new }.to raise_exception(ArgumentError)
   end
 end

--- a/spec/required_spec.rb
+++ b/spec/required_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe "required param" do
+  before do
+    class Test::Foo
+      extend Dry::Initializer
+
+      param :foo
+      param :bar, optional: true
+    end
+  end
+
+  it "raise ArgumentError" do
+    expect { Test::Foo.new() }.to raise_exception(ArgumentError)
+  end
+end
+
+describe "required option" do
+  before do
+    class Test::Foo
+      extend Dry::Initializer
+
+      option :foo
+      option :bar, optional: true
+    end
+  end
+
+  it "raise ArgumentError" do
+    expect { Test::Foo.new() }.to raise_exception(ArgumentError)
+  end
+end

--- a/spec/several_assignments_spec.rb
+++ b/spec/several_assignments_spec.rb
@@ -6,7 +6,7 @@ describe "attribute with several assignments" do
       extend Dry::Initializer
 
       option :bar, proc(&:to_s), optional: true
-      option :some_foo, as: :bar, optional: true
+      option "some_foo", as: :bar, optional: true
     end
   end
 
@@ -29,7 +29,7 @@ describe "attribute with several assignments" do
   end
 
   context "when renamed" do
-    subject { Test::Foo.new some_foo: :BAZ }
+    subject { Test::Foo.new "some_foo": :BAZ }
 
     it "renames the attribute" do
       expect(subject.bar).to eq :BAZ

--- a/spec/several_assignments_spec.rb
+++ b/spec/several_assignments_spec.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 describe "attribute with several assignments" do
   before do
     class Test::Foo
       extend Dry::Initializer
 
-      option :bar, proc(&:to_s),    optional: true
-      option :"some foo", as: :bar, optional: true
+      option :bar, proc(&:to_s), optional: true
+      option :some_foo, as: :bar, optional: true
     end
   end
 
@@ -13,7 +15,7 @@ describe "attribute with several assignments" do
 
     it "is left undefined" do
       expect(subject.bar).to be_nil
-      expect(subject.instance_variable_get :@bar)
+      expect(subject.instance_variable_get(:@bar))
         .to eq Dry::Initializer::UNDEFINED
     end
   end
@@ -27,7 +29,7 @@ describe "attribute with several assignments" do
   end
 
   context "when renamed" do
-    subject { Test::Foo.new "some foo": :BAZ }
+    subject { Test::Foo.new some_foo: :BAZ }
 
     it "renames the attribute" do
       expect(subject.bar).to eq :BAZ

--- a/spec/unknown_spec.rb
+++ b/spec/unknown_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+describe "unknow param" do
+  before do
+    class Test::Foo
+      extend Dry::Initializer
+
+      param :foo
+      param :bar, optional: true
+    end
+  end
+
+  it "suports unknown params" do
+    subject = Test::Foo.new(1, 2, 3, 4)
+
+    expect(subject.__dry_initializer_unknown_params__).to eq([3, 4])
+  end
+
+  it "suports unknown params with last as hash" do
+    subject = Test::Foo.new(1, 2, 3, {fizz: 4})
+
+    expect(subject.__dry_initializer_unknown_params__).to eq([3, {fizz: 4}])
+  end
+
+  context "with custom rest params" do
+    before do
+      class Test::Bar
+        extend Dry::Initializer
+  
+        param :foo
+        param :bar, optional: true
+        rest_params :qux
+      end
+    end
+
+    it "supports unknown options" do
+      subject = Test::Bar.new(1, 2, 3, 4)
+
+      expect(subject.qux).to eq([3, 4])
+    end
+  end
+
+  context "without rest params" do
+    before do
+      class Test::Bar
+        extend Dry::Initializer
+  
+        param :foo
+        param :bar, optional: true
+        rest_params false
+      end
+    end
+
+    it "raise an ArgumentError" do
+      expect { Test::Bar.new(1, 2, 3, 4) }.to raise_exception ArgumentError
+    end
+  end
+end
+
+describe "unknown option" do
+  before do
+    class Test::Foo
+      extend Dry::Initializer
+
+      option :foo
+      option :bar, optional: true
+    end
+  end
+
+  it "supports unknown options" do
+    subject = Test::Foo.new(foo: 1, bar: 2, fizz: 3, buzz: 4)
+
+    expect(subject.__dry_initializer_unknown_options__).to eq(fizz: 3, buzz: 4)
+  end
+
+  context "with custom rest options" do
+    before do
+      class Test::Bar
+        extend Dry::Initializer
+  
+        option :foo
+        option :bar, optional: true
+        rest_options :kwargs
+      end
+    end
+
+    it "supports unknown options" do
+      subject = Test::Bar.new(foo: 1, bar: 2, fizz: 3, buzz: 4)
+  
+      expect(subject.kwargs).to eq(fizz: 3, buzz: 4)
+    end
+  end
+
+  context "with out rest options" do
+    before do
+      class Test::Bar
+        extend Dry::Initializer
+  
+        option :foo
+        option :bar, optional: true
+        rest_options false
+      end
+    end
+
+    it "raise an ArgumentError" do
+      expect { Test::Bar.new(foo: 1, bar: 2, fizz: 3, buzz: 4) }.to raise_exception ArgumentError
+    end
+  end
+end

--- a/spec/unknown_spec.rb
+++ b/spec/unknown_spec.rb
@@ -26,7 +26,7 @@ describe "unknow param" do
     before do
       class Test::Bar
         extend Dry::Initializer
-  
+
         param :foo
         param :bar, optional: true
         rest_params :qux
@@ -44,7 +44,7 @@ describe "unknow param" do
     before do
       class Test::Bar
         extend Dry::Initializer
-  
+
         param :foo
         param :bar, optional: true
         rest_params false
@@ -77,7 +77,7 @@ describe "unknown option" do
     before do
       class Test::Bar
         extend Dry::Initializer
-  
+
         option :foo
         option :bar, optional: true
         rest_options :kwargs
@@ -86,7 +86,7 @@ describe "unknown option" do
 
     it "supports unknown options" do
       subject = Test::Bar.new(foo: 1, bar: 2, fizz: 3, buzz: 4)
-  
+
       expect(subject.kwargs).to eq(fizz: 3, buzz: 4)
     end
   end
@@ -95,7 +95,7 @@ describe "unknown option" do
     before do
       class Test::Bar
         extend Dry::Initializer
-  
+
         option :foo
         option :bar, optional: true
         rest_options false


### PR DESCRIPTION
 ### default behavior remains unchanged
 
 Unknown params and options are ignored but stored in their own attr_reader
 
 ```ruby
 class Test::Foo
  extend Dry::Initializer

  param :foo
  param :bar, optional: true
end

foo = Test::Foo.new(1, 2, 3, 4)
foo.__dry_initializer_unknown_params__ # => [3, 4]
```

 ```ruby
 class Test::Foo
  extend Dry::Initializer

  option :foo
  options :bar, optional: true
end

foo = Test::Foo.new(foo: 1, bar: 2, fizz: 3, buzz: 4)
foo.__dry_initializer_unknown_options__ # => {fizz: 3, buzz: 4}
```
    
### rest params and rest options names are configurable

 ```ruby
 class Test::Foo
  extend Dry::Initializer

  param :foo
  param :bar, optional: true
  rest_param :unknown_params
end

foo = Test::Foo.new(1, 2, 3, 4)
foo.unknown_params # => [3, 4]
```

 ```ruby
 class Test::Foo
  extend Dry::Initializer

  option :foo
  options :bar, optional: true
  rest_options :unknown_options
end

foo = Test::Foo.new(foo: 1, bar: 2, fizz: 3, buzz: 4)
foo.unknown_options # => {fizz: 3, buzz: 4}
```

### rest params and rest options can be turned off for strict mode

This adds support for strict checking of params and options: #68

 ```ruby
 class Test::Foo
  extend Dry::Initializer

  param :foo
  param :bar, optional: true
  rest_param false
end

Test::Foo.new(1, 2, 3, 4) => raises ArgumentError
```

 ```ruby
 class Test::Foo
  extend Dry::Initializer

  option :foo
  options :bar, optional: true
  rest_options :unknown_options
end

Test::Foo.new(foo: 1, bar: 2, fizz: 3, buzz: 4) # raises ArgumentError
```

