### PR TITLE
Fix typo in attributes docs

### DIFF
--- a/docsite/source/attributes.html.md
+++ b/docsite/source/attributes.html.md
@@ -6,7 +6,7 @@ name: dry-initializer
 
 Sometimes you need to access all attributes assigned via params and options of the object constructor.
 
-We support 2 methods: `attributes` and `public_attributes` for this goal. Both methods are wrapped into container accessible via `.dry_types` container:
+We support 2 methods: `attributes` and `public_attributes` for this goal. Both methods are wrapped into container accessible via `.dry_initializer` container:
 
 ```ruby
 require 'dry-initializer'


### PR DESCRIPTION
The text mentions `.dry_types` but the code examples use `.dry_initializer`.