### PR TITLE
correct typo

### DIFF
--- a/docsite/source/params-and-options.html.md
+++ b/docsite/source/params-and-options.html.md
@@ -38,7 +38,7 @@ user.name  # => 'Andrew'
 user.email # => 'andrew@email.com'
 ```
 
-Options can be renamed using `:as` key:
+Options can be renamed using `as:` key:
 
 ```ruby
 require 'dry-initializer'


### PR DESCRIPTION
I guess as: is meant
(According to the instances in the example)