### PR TITLE
Fix PrepareDefault#callable! default check with false

### DIFF
--- a/lib/dry/initializer/dispatchers/prepare_default.rb
+++ b/lib/dry/initializer/dispatchers/prepare_default.rb
@@ -20,7 +20,7 @@ module Dry
         private
 
         def callable!(default)
-          return unless default
+          return if default.nil? # handles false case better than `unless default`
           return default if default.respond_to?(:call)
           return callable(default.to_proc) if default.respond_to?(:to_proc)
 
@@ -38,7 +38,7 @@ module Dry
 
         def invalid!(default)
           raise TypeError, "The #{default.inspect} should be" \
-                           " either convertable to proc with no arguments," \
+                           " either convertible to proc with no arguments," \
                            " or respond to #call without arguments."
         end
       end

--- a/spec/invalid_default_spec.rb
+++ b/spec/invalid_default_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe "invalid default value assignment" do
+  shared_examples "it has a TypeError" do
+    it "raises TypeError" do
+      expect { subject }.to raise_error TypeError
+    end
+  end
+
   subject do
     class Test::Foo
       extend Dry::Initializer
@@ -9,7 +15,31 @@ RSpec.describe "invalid default value assignment" do
     end
   end
 
-  it "raises TypeError" do
-    expect { subject }.to raise_error TypeError
+  it_behaves_like "it has a TypeError"
+
+  context "when default is false" do
+    subject do
+      class Test::Foo
+        extend Dry::Initializer
+
+        param :foo, default: false
+      end
+    end
+
+    it_behaves_like "it has a TypeError"
+  end
+
+  context "when default is a lambda returning false" do
+    subject do
+      class Test::Foo
+        extend Dry::Initializer
+
+        param :foo, default: -> { false }
+      end
+    end
+
+    it "does not raise TypeError" do
+      expect { subject }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the `callable!` check which was not raising when setting `default: false`, even though it does when setting `default: true`.

⚠️ This is a breaking change! As it will break for everyone who has set `default: false` in the past.
- I believe this should trigger a major version bump because of it.
- Not sure if I need to update changelog and version number myself, lmk and I'll update this PR.

(Note: I re-used some of @skryukov code from https://github.com/dry-rb/dry-initializer/pull/93 for specs `shared_examples`)