### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+        - "3.2"
         - "3.1"
         - "3.0"
-        - "2.7"
         include:
           - ruby: "3.1"
             coverage: "true"
@@ -36,7 +36,7 @@ jobs:
       COVERAGE_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install package dependencies
         run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
       - name: Set up Ruby
@@ -65,7 +65,7 @@ jobs:
       GITHUB_LOGIN: dry-bot
       GITHUB_TOKEN: ${{secrets.GH_PAT}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install package dependencies
         run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
       - name: Set up Ruby

--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -16,7 +16,7 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: |

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -28,7 +28,7 @@ jobs:
         type: ["Style", "Layout", "Naming", "Lint", "Metrics", "Security"]
     steps:
     - name: Clone
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Get git diff
       id: get_diff
       uses: technote-space/get-diff-action@v4

--- a/.github/workflows/sync_configs.yml
+++ b/.github/workflows/sync_configs.yml
@@ -17,9 +17,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Checkout ${{github.repository}}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout devtools
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: dry-rb/devtools
           path: tmp/devtools


### PR DESCRIPTION
Removes Ruby 2.7 job which fails because the gem no longer supports Rubies earlier than 3.0.0.

Also updates checkout actions to v3.

Runs green on my fork.