### PR TITLE
improved root initializer args for ruby 3.*.* / fixed ruby deprecation

### DIFF
--- a/lib/dry/initializer/mixin/root.rb
+++ b/lib/dry/initializer/mixin/root.rb
@@ -7,8 +7,8 @@ module Dry
       module Root
         private
 
-        def initialize(...)
-          __dry_initializer_initialize__(...)
+        def initialize(args)
+          __dry_initializer_initialize__(**args)
         end
       end
     end


### PR DESCRIPTION
This's small fix is provide to use dry-initializer gem with ruby 3